### PR TITLE
Properly remove Skrump from channels.txt

### DIFF
--- a/automation/channels.txt
+++ b/automation/channels.txt
@@ -61,7 +61,6 @@ UCHEMKKC8wrdShkK-UYYXz7A;Sam Dekker Superfan
 UCllgnCgIvlX5qr9hnCOe4lw;sambagels
 UC-uZfOZtaq9OQyEXEVfkDGA;samquik
 UCs8splaCDYScDNe4L1VWSyA;skipz
-UCgh-KYCe4_3_TqUbgtTDrnA;skrump
 UCmoocNPdc3EYwgmFyB3KHzg;skye4;🐶
 UC89uPIP2rmjw4eKL2X9sawA;smolbeanjerma
 UCSmFebAF9cHGTATiYh74M6w;SmurfKobain


### PR DESCRIPTION
Removing from MD file just restores Skrump back onto the list, this removes the channel ID from channels.txt